### PR TITLE
Fix prefixing for grid-column/row-span

### DIFF
--- a/modules/__tests__/createPrefixer-test.js
+++ b/modules/__tests__/createPrefixer-test.js
@@ -491,7 +491,7 @@ describe('Static Prefixer', () => {
             gridColumnEnd: 5,
             gridColumnStart: 2,
             msGridColumn: 2,
-            msGridColumnSpan: 3,
+            msGridColumnSpan: '3',
           }
           expect(prefix(input)).toEqual(output)
         })
@@ -502,7 +502,7 @@ describe('Static Prefixer', () => {
             gridRowEnd: 7,
             gridRowStart: 3,
             msGridRow: 3,
-            msGridRowSpan: 4,
+            msGridRowSpan: '4',
           }
           expect(prefix(input)).toEqual(output)
         })
@@ -521,7 +521,7 @@ describe('Static Prefixer', () => {
           const output = {
             gridColumn: '3 / 5',
             msGridColumn: 3,
-            msGridColumnSpan: 2,
+            msGridColumnSpan: '2',
           }
           expect(prefix(input)).toEqual(output)
         })
@@ -531,7 +531,7 @@ describe('Static Prefixer', () => {
           const output = {
             gridRow: '2 / 7',
             msGridRow: 2,
-            msGridRowSpan: 5,
+            msGridRowSpan: '5',
           }
           expect(prefix(input)).toEqual(output)
         })

--- a/modules/plugins/grid.js
+++ b/modules/plugins/grid.js
@@ -31,7 +31,7 @@ const propertyConverters = {
   gridColumnEnd: (value: any, style: Object) => {
     const { msGridColumn } = style
     if (isSimplePositionValue(value) && isSimplePositionValue(msGridColumn)) {
-      style.msGridColumnSpan = value - msGridColumn
+      style.msGridColumnSpan = String(value - msGridColumn)
     }
   },
 
@@ -54,7 +54,7 @@ const propertyConverters = {
   gridRowEnd: (value: any, style: Object) => {
     const { msGridRow } = style
     if (isSimplePositionValue(value) && isSimplePositionValue(msGridRow)) {
-      style.msGridRowSpan = value - msGridRow
+      style.msGridRowSpan = String(value - msGridRow)
     }
   },
 
@@ -88,7 +88,7 @@ export default function grid(
     return displayValues[value]
   }
 
-  if (property in propertyConverters) {
+  if (property in propertyConverters && typeof value !== 'undefined') {
     const propertyConverter = propertyConverters[property]
     propertyConverter(value, style)
   }


### PR DESCRIPTION
It turns out that using an integer value for `msGrid(Column|Row)Span` causes the style to be interpreted as a unitless length value, which means it ends up as `${value}px` instead of just `${value}`. Unfortunately, that's not what we want - we expect this to refer to a line position on the grid.

I also took the opportunity to fix https://github.com/robinweser/inline-style-prefixer/issues/176, although I think the conditions for producing that error are far off the beaten path.