### PR TITLE
Removes all references to ie_mob

### DIFF
--- a/benchmark/packages/205/plugins/flexboxIE.js
+++ b/benchmark/packages/205/plugins/flexboxIE.js
@@ -42,7 +42,7 @@ function flexboxIE(_ref) {
   var css = _ref.prefix.css;
   var keepUnprefixed = _ref.keepUnprefixed;
 
-  if ((alternativeProps[property] || property === 'display' && typeof value === 'string' && value.indexOf('flex') > -1) && (browser === 'ie_mob' || browser === 'ie') && version == 10) {
+  if ((alternativeProps[property] || property === 'display' && typeof value === 'string' && value.indexOf('flex') > -1) && browser === 'ie' && version == 10) {
     if (!keepUnprefixed && !Array.isArray(styles[property])) {
       delete styles[property];
     }

--- a/benchmark/packages/300/dynamic/plugins/flexboxIE.js
+++ b/benchmark/packages/300/dynamic/plugins/flexboxIE.js
@@ -38,7 +38,7 @@ function flexboxIE(property, value, style, _ref) {
       keepUnprefixed = _ref.keepUnprefixed,
       requiresPrefix = _ref.requiresPrefix;
 
-  if ((alternativeProps[property] || property === 'display' && typeof value === 'string' && value.indexOf('flex') > -1) && (browserName === 'ie_mob' || browserName === 'ie') && browserVersion === 10) {
+  if ((alternativeProps[property] || property === 'display' && typeof value === 'string' && value.indexOf('flex') > -1) && browserName === 'ie' && browserVersion === 10) {
     delete requiresPrefix[property];
 
     if (!keepUnprefixed && !Array.isArray(style[property])) {

--- a/benchmark/packages/301/dynamic/plugins/flexboxIE.js
+++ b/benchmark/packages/301/dynamic/plugins/flexboxIE.js
@@ -38,7 +38,7 @@ function flexboxIE(property, value, style, _ref) {
       keepUnprefixed = _ref.keepUnprefixed,
       requiresPrefix = _ref.requiresPrefix;
 
-  if ((alternativeProps.hasOwnProperty(property) || property === 'display' && typeof value === 'string' && value.indexOf('flex') > -1) && (browserName === 'ie_mob' || browserName === 'ie') && browserVersion === 10) {
+  if ((alternativeProps.hasOwnProperty(property) || property === 'display' && typeof value === 'string' && value.indexOf('flex') > -1) && browserName === 'ie' && browserVersion === 10) {
     delete requiresPrefix[property];
 
     if (!keepUnprefixed && !Array.isArray(style[property])) {

--- a/benchmark/packages/302/dynamic/plugins/flexboxIE.js
+++ b/benchmark/packages/302/dynamic/plugins/flexboxIE.js
@@ -38,7 +38,7 @@ function flexboxIE(property, value, style, _ref) {
       keepUnprefixed = _ref.keepUnprefixed,
       requiresPrefix = _ref.requiresPrefix;
 
-  if ((alternativeProps.hasOwnProperty(property) || property === 'display' && typeof value === 'string' && value.indexOf('flex') > -1) && (browserName === 'ie_mob' || browserName === 'ie') && browserVersion === 10) {
+  if ((alternativeProps.hasOwnProperty(property) || property === 'display' && typeof value === 'string' && value.indexOf('flex') > -1) && browserName === 'ie' && browserVersion === 10) {
     delete requiresPrefix[property];
 
     if (!keepUnprefixed && !Array.isArray(style[property])) {

--- a/docs/api/generator/generateData.md
+++ b/docs/api/generator/generateData.md
@@ -39,7 +39,6 @@ const browserList = {
   ios_saf: 8,
   safari: 8,
   ie: 11,
-  ie_mob: 11,
   edge: 12,
   opera: 16,
   op_mini: 12,

--- a/docs/guides/CustomPrefixer.md
+++ b/docs/guides/CustomPrefixer.md
@@ -24,7 +24,6 @@ const browserList = {
   ios_saf: 8,
   safari: 8,
   ie: 11,
-  ie_mob: 11,
   edge: 12,
   opera: 16,
   op_mini: 12,

--- a/generateDefaultData.js
+++ b/generateDefaultData.js
@@ -7,7 +7,6 @@ const defaultBrowserSupport = {
   ios_saf: 9,
   safari: 9,
   ie: 11,
-  ie_mob: 11,
   edge: 12,
   opera: 30,
   op_mini: 12,

--- a/modules/__tests__/createPrefixer-test.js
+++ b/modules/__tests__/createPrefixer-test.js
@@ -9,7 +9,6 @@ const browserList = {
   ios_saf: 0,
   safari: 0,
   ie: 0,
-  ie_mob: 0,
   edge: 0,
   opera: 0,
   op_mini: 0,
@@ -346,7 +345,6 @@ describe('Static Prefixer', () => {
       const input = { writingMode: 'horizontal-tb' }
       const output = {
         WebkitWritingMode: 'horizontal-tb',
-        msWritingMode: 'horizontal-tb',
         writingMode: 'horizontal-tb',
       }
       expect(prefix(input)).toEqual(output)

--- a/modules/generator/generatePrefixMap.js
+++ b/modules/generator/generatePrefixMap.js
@@ -15,7 +15,6 @@ const prefixBrowserMap = {
   and_chr: 'Webkit',
   and_uc: 'Webkit',
   op_mini: 'Webkit',
-  ie_mob: 'ms',
 }
 
 // remove flexprops from IE

--- a/modules/generator/maps/pluginMap.js
+++ b/modules/generator/maps/pluginMap.js
@@ -42,7 +42,6 @@ export default {
     opera: 16,
   },
   flexboxIE: {
-    ie_mob: 11,
     ie: 11,
   },
   flexboxOld: {
@@ -66,7 +65,6 @@ export default {
   grid: {
     edge: 16,
     ie: 11,
-    ie_mob: 11,
   },
   imageSet: {
     chrome: maximumVersion,
@@ -103,7 +101,6 @@ export default {
     and_uc: maximumVersion,
     ios_saf: maximumVersion,
     msie: maximumVersion,
-    ie_mob: maximumVersion,
     edge: maximumVersion,
     firefox: maximumVersion,
     op_mini: maximumVersion,


### PR DESCRIPTION
`ie_mob` has been marked as a dead browser by `browserslist` and is thus no longer returned in `caniuse-api` queries when it depends on latest `browserslist`.

This pull request removes all references to `ie_mob` from the codebase and documentation.

Fixes #191