### PR TITLE
perf: reduce bundle size

### DIFF
--- a/modules/plugins/calc.js
+++ b/modules/plugins/calc.js
@@ -1,7 +1,6 @@
 /* @flow */
 import isPrefixedValue from 'css-in-js-utils/lib/isPrefixedValue'
-
-const prefixes = ['-webkit-', '-moz-', '']
+import { prefixesWebkitAndMoz as prefixes } from '../utils/constants'
 
 export default function calc(property: string, value: any): ?Array<string> {
   if (

--- a/modules/plugins/crossFade.js
+++ b/modules/plugins/crossFade.js
@@ -2,7 +2,7 @@
 import isPrefixedValue from 'css-in-js-utils/lib/isPrefixedValue'
 
 // http://caniuse.com/#search=cross-fade
-const prefixes = ['-webkit-', '']
+import { prefixesWebkit as prefixes } from '../utils/constants'
 
 export default function crossFade(
   property: string,

--- a/modules/plugins/cursor.js
+++ b/modules/plugins/cursor.js
@@ -1,15 +1,10 @@
 /* @flow */
-const prefixes = ['-webkit-', '-moz-', '']
+import { prefixesWebkitAndMoz as prefixes } from '../utils/constants'
 
-const values = {
-  'zoom-in': true,
-  'zoom-out': true,
-  grab: true,
-  grabbing: true,
-}
+const values = ['zoom-in', 'zoom-out', 'grab', 'grabbing']
 
 export default function cursor(property: string, value: any): ?Array<string> {
-  if (property === 'cursor' && values.hasOwnProperty(value)) {
+  if (property === 'cursor' && values.indexOf(value) > -1) {
     return prefixes.map((prefix) => prefix + value)
   }
 }

--- a/modules/plugins/filter.js
+++ b/modules/plugins/filter.js
@@ -2,7 +2,7 @@
 import isPrefixedValue from 'css-in-js-utils/lib/isPrefixedValue'
 
 // http://caniuse.com/#feat=css-filter-function
-const prefixes = ['-webkit-', '']
+import { prefixesWebkit as prefixes } from '../utils/constants'
 
 export default function filter(property: string, value: any): ?Array<string> {
   if (

--- a/modules/plugins/flexboxOld.js
+++ b/modules/plugins/flexboxOld.js
@@ -21,16 +21,8 @@ export default function flexboxOld(
   style: Object
 ): void {
   if (property === 'flexDirection' && typeof value === 'string') {
-    if (value.indexOf('column') > -1) {
-      style.WebkitBoxOrient = 'vertical'
-    } else {
-      style.WebkitBoxOrient = 'horizontal'
-    }
-    if (value.indexOf('reverse') > -1) {
-      style.WebkitBoxDirection = 'reverse'
-    } else {
-      style.WebkitBoxDirection = 'normal'
-    }
+    style.WebkitBoxOrient = value.indexOf('column') > -1 ? 'vertical' : 'horizontal'
+    style.WebkitBoxDirection = value.indexOf('reverse') > -1 ? 'reverse' : 'normal'
   }
   if (alternativeProps.hasOwnProperty(property)) {
     style[alternativeProps[property]] = alternativeValues[value] || value

--- a/modules/plugins/gradient.js
+++ b/modules/plugins/gradient.js
@@ -1,7 +1,7 @@
 /* @flow */
 import isPrefixedValue from 'css-in-js-utils/lib/isPrefixedValue'
+import { prefixesWebkitAndMoz as prefixes } from '../utils/constants'
 
-const prefixes = ['-webkit-', '-moz-', '']
 const values = /linear-gradient|radial-gradient|repeating-linear-gradient|repeating-radial-gradient/gi
 
 export default function gradient(property: string, value: any): ?Array<string> {

--- a/modules/plugins/grid.js
+++ b/modules/plugins/grid.js
@@ -30,11 +30,10 @@ const propertyConverters = {
       propertyConverters.gridColumnStart(+start, style)
 
       const [maybeSpan, maybeNumber] = end.split(/ ?span /)
-      if (maybeSpan === '') {
-        propertyConverters.gridColumnEnd(+start + +maybeNumber, style)
-      } else {
-        propertyConverters.gridColumnEnd(+end, style)
-      }
+      propertyConverters.gridColumnEnd(
+        maybeSpan === '' ? +start + +maybeNumber : +end,
+        style
+      )
     } else {
       propertyConverters.gridColumnStart(value, style)
     }
@@ -61,11 +60,10 @@ const propertyConverters = {
       propertyConverters.gridRowStart(+start, style)
 
       const [maybeSpan, maybeNumber] = end.split(/ ?span /)
-      if (maybeSpan === '') {
-        propertyConverters.gridRowEnd(+start + +maybeNumber, style)
-      } else {
-        propertyConverters.gridRowEnd(+end, style)
-      }
+      propertyConverters.gridRowEnd(
+        maybeSpan === '' ? +start + +maybeNumber : +end,
+        style
+      )
     } else {
       propertyConverters.gridRowStart(value, style)
     }

--- a/modules/plugins/imageSet.js
+++ b/modules/plugins/imageSet.js
@@ -2,7 +2,7 @@
 import isPrefixedValue from 'css-in-js-utils/lib/isPrefixedValue'
 
 // http://caniuse.com/#feat=css-image-set
-const prefixes = ['-webkit-', '']
+import { prefixesWebkit as prefixes } from '../utils/constants'
 
 export default function imageSet(property: string, value: any): ?Array<string> {
   if (

--- a/modules/plugins/sizing.js
+++ b/modules/plugins/sizing.js
@@ -1,25 +1,11 @@
 /* @flow */
-const prefixes = ['-webkit-', '-moz-', '']
+import { prefixesWebkitAndMoz as prefixes } from '../utils/constants'
 
-const properties = {
-  maxHeight: true,
-  maxWidth: true,
-  width: true,
-  height: true,
-  columnWidth: true,
-  minWidth: true,
-  minHeight: true,
-}
-const values = {
-  'min-content': true,
-  'max-content': true,
-  'fill-available': true,
-  'fit-content': true,
-  'contain-floats': true,
-}
+const properties = ['maxHeight', 'maxWidth', 'width', 'height', 'columnWidth', 'minWidth', 'minHeight']
+const values = ['min-content', 'max-content', 'fill-available', 'fit-content', 'contain-floats']
 
 export default function sizing(property: string, value: any): ?Array<any> {
-  if (properties.hasOwnProperty(property) && values.hasOwnProperty(value)) {
+  if (properties.indexOf(property) > -1 && values.indexOf(value) > -1) {
     return prefixes.map((prefix) => prefix + value)
   }
 }

--- a/modules/plugins/transition.js
+++ b/modules/plugins/transition.js
@@ -4,14 +4,7 @@ import isPrefixedValue from 'css-in-js-utils/lib/isPrefixedValue'
 
 import capitalizeString from '../utils/capitalizeString'
 
-const properties = {
-  transition: true,
-  transitionProperty: true,
-  WebkitTransition: true,
-  WebkitTransitionProperty: true,
-  MozTransition: true,
-  MozTransitionProperty: true,
-}
+const properties = ['transition', 'transitionProperty', 'WebkitTransition', 'WebkitTransitionProperty', 'MozTransition', 'MozTransitionProperty']
 
 const prefixMapping = {
   Webkit: '-webkit-',
@@ -19,13 +12,15 @@ const prefixMapping = {
   ms: '-ms-',
 }
 
+const rTransitionSplitter = /,(?![^()]*(?:\([^()]*\))?\))/g
+
 function prefixValue(value: string, propertyPrefixMap: Object): string {
   if (isPrefixedValue(value)) {
     return value
   }
 
   // only split multi values, not cubic beziers
-  const multipleValues = value.split(/,(?![^()]*(?:\([^()]*\))?\))/g)
+  const multipleValues = value.split(rTransitionSplitter)
 
   for (let i = 0, len = multipleValues.length; i < len; ++i) {
     const singleValue = multipleValues[i]
@@ -63,11 +58,12 @@ export default function transition(
   propertyPrefixMap: Object
 ): ?string {
   // also check for already prefixed transitions
-  if (typeof value === 'string' && properties.hasOwnProperty(property)) {
+  if (typeof value === 'string' && properties.indexOf(property) > -1) {
     const outputValue = prefixValue(value, propertyPrefixMap)
     // if the property is already prefixed
-    const webkitOutput = outputValue
-      .split(/,(?![^()]*(?:\([^()]*\))?\))/g)
+    const multipleValues = outputValue.split(rTransitionSplitter)
+
+    const webkitOutput = multipleValues
       .filter((val) => !/-moz-|-ms-/.test(val))
       .join(',')
 
@@ -75,8 +71,7 @@ export default function transition(
       return webkitOutput
     }
 
-    const mozOutput = outputValue
-      .split(/,(?![^()]*(?:\([^()]*\))?\))/g)
+    const mozOutput = multipleValues
       .filter((val) => !/-webkit-|-ms-/.test(val))
       .join(',')
 

--- a/modules/utils/constants.js
+++ b/modules/utils/constants.js
@@ -1,0 +1,3 @@
+/* @flow */
+export const prefixesWebkitAndMoz = ['-webkit-', '-moz-', '']
+export const prefixesWebkit = ['-webkit-', '']


### PR DESCRIPTION
Changes to reduce the final bundle size:

- Extract the constants (e.g. `['-webkit-', '-moz-', '']`).
- Prefer `Array#indexOf` over `Object#hasOwnProperty` when possible.
- Prefer ternary expressions