### PR TITLE
Remove backgroundClip from pluginMap

### DIFF
--- a/modules/generator/maps/pluginMap.js
+++ b/modules/generator/maps/pluginMap.js
@@ -2,16 +2,6 @@
 const maximumVersion = 9999
 
 export default {
-  backgroundClip: {
-    chrome: maximumVersion,
-    safari: maximumVersion,
-    opera: maximumVersion,
-    and_chr: maximumVersion,
-    ios_saf: maximumVersion,
-    edge: maximumVersion,
-    firefox: maximumVersion,
-    op_mini: maximumVersion,
-  },
   calc: {
     firefox: 15,
     chrome: 25,


### PR DESCRIPTION
The PR continues from #221.

The `backgroundClip` plugin has been removed in #221. Removes it from `pluginMap` as well.

cc @robinweser 